### PR TITLE
Impl/graphics bridge and python 3.5 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ c:
 	rm todel.gml
 g:
 	python -m phasme generate out/todel powerlaw_cluster_graph n=5 m=2 p=0.01
+graphics:
+	python -m phasme infos data/test.gml --graphics --graphics-params logxscale=1 logyscale=1
 tex:
 	python -m phasme convert data/realgraph.lp todel.tex
 

--- a/phasme/__main__.py
+++ b/phasme/__main__.py
@@ -10,7 +10,9 @@ def run_cli():
 
     if args.command == 'infos':
         infos = routines.info(args.infile, args.motifs, args.no_cc,
-                              graphics=args.graphics, outdir=args.outdir,
+                              graphics=args.graphics,
+                              graphics_params=args.graphics_params,
+                              outdir=args.outdir,
                               heavy_computations=args.heavy_computations,
                               special_nodes=args.special_nodes,
                               graph_properties=args.graph_properties,

--- a/phasme/graphics.py
+++ b/phasme/graphics.py
@@ -32,11 +32,11 @@ def make_all(graph, outdir:str, params:dict=None):
 
 
 def choose_name(outdir, file_name:str):
-    i = 1
-    file_path = f"{outdir}/{file_name}.png"
+    idx = 1
+    file_path = '{}/{}.png'.format(outdir, file_name)
     while os.path.exists(file_path):
-        file_path = f"{outdir}/{file_name}_{i}.png"
-        i += 1
+        file_path = '{}/{}_{}.png'.format(outdir, file_name, idx)
+        idx += 1
     return file_path
 
 

--- a/phasme/info.py
+++ b/phasme/info.py
@@ -12,7 +12,7 @@ from phasme import graphics as graphics_module
 
 
 def yield_info(fname:str, info_motifs:int=0, info_ccs:bool=True,
-               graphics:bool=False, outdir:str='.',
+               graphics:bool=False, graphics_params:dict={}, outdir:str='.',
                special_nodes:bool=False,
                heavy_computations:bool=False, graph_properties:bool=False,
                negative_results:bool=True,
@@ -58,7 +58,7 @@ def yield_info(fname:str, info_motifs:int=0, info_ccs:bool=True,
             yield 'density/cc', tuple(density(len(nodes), len(tuple(cc.edges))) for cc, nodes in zip(ccs, ccs_nodes))
 
     if graphics:
-        nb_graphics = sum(1 for _ in graphics_module.make_all(graph, outdir))
+        nb_graphics = sum(1 for _ in graphics_module.make_all(graph, outdir, graphics_params))
         yield '#graphics', nb_graphics
 
     if heavy_computations:
@@ -96,13 +96,13 @@ def yield_info(fname:str, info_motifs:int=0, info_ccs:bool=True,
 
 
 def info(fname:str, info_motifs:int=0, info_ccs:bool=True,
-         graphics:bool=False, outdir:str='.',
+         graphics:bool=False, graphics_params:dict={}, outdir:str='.',
          special_nodes:bool=False, heavy_computations:bool=False,
          graph_properties:bool=False,
          round_float:int=None,
          negative_results:bool=True, edge_predicate:str=edge_predicate) -> dict:
     """Yield lines of text describing given graph info."""
-    infos = OrderedDict(yield_info(fname, info_motifs, info_ccs, graphics, outdir, special_nodes, heavy_computations, graph_properties, negative_results, edge_predicate))
+    infos = OrderedDict(yield_info(fname, info_motifs, info_ccs, graphics, graphics_params, outdir, special_nodes, heavy_computations, graph_properties, negative_results, edge_predicate))
     properties = {True: set(), False: set()}
     maxkeylen = max(map(len, infos))
     iter_handler = lambda v: ', '.join(sorted(map(str, v)))


### PR DESCRIPTION
Implements CLI parsing of parameters, and passing toward `graphics.make_all` function.
Note that the call of graphics routines with logxscale and logyscale lead to an error.

Command (see `graphics` recipe in Makefile):
```
python -m phasme infos data/test.gml --graphics --graphics-params logxscale=True logyscale=True
```

Stack trace:
```
Traceback (most recent call last):
  File "/usr/lib64/python3.5/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib64/python3.5/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/lbourneu/programs/phasme/phasme/__main__.py", line 48, in <module>
    run_cli()
  File "/home/lbourneu/programs/phasme/phasme/__main__.py", line 22, in run_cli
    print('\n'.join(infos))
  File "/home/lbourneu/programs/phasme/phasme/info.py", line 105, in info
    infos = OrderedDict(yield_info(fname, info_motifs, info_ccs, graphics, graphics_params, outdir, special_nodes, heavy_computations, graph_properties, negative_results, edge_predicate))
  File "/home/lbourneu/programs/phasme/phasme/info.py", line 61, in yield_info
    nb_graphics = sum(1 for _ in graphics_module.make_all(graph, outdir, graphics_params))
  File "/home/lbourneu/programs/phasme/phasme/info.py", line 61, in <genexpr>
    nb_graphics = sum(1 for _ in graphics_module.make_all(graph, outdir, graphics_params))
  File "/home/lbourneu/programs/phasme/phasme/graphics.py", line 28, in make_all
    outfile = func(graph, outdir, **{p: v for p, v in params.items() if p in func_params})
  File "/home/lbourneu/programs/phasme/phasme/graphics.py", line 46, in make_graphics_degree
    degrees = list(graph.degree().values())
AttributeError: 'DegreeView' object has no attribute 'values'
```

